### PR TITLE
Add concurrency protection to injector

### DIFF
--- a/internal/injector/injector_test.go
+++ b/internal/injector/injector_test.go
@@ -101,7 +101,7 @@ func TestSecretInjector(t *testing.T) {
 			results[key] = value
 		}
 
-		err = injector.InjectSecretsFromVault(references, injectFunc)
+		err := injector.InjectSecretsFromVault(references, injectFunc)
 		require.NoError(t, err)
 
 		// This tests caching of dynamic secrets in calls. We can't predict
@@ -125,8 +125,7 @@ func TestSecretInjector(t *testing.T) {
 	})
 
 	t.Run("correct path but missing secret", func(t *testing.T) {
-		// TODO: fix race condition
-		// t.Parallel()
+		t.Parallel()
 
 		references := map[string]string{
 			"SECRET": "vault:secret/data/supersecret#password",
@@ -138,13 +137,12 @@ func TestSecretInjector(t *testing.T) {
 			results[key] = value
 		}
 
-		err = injector.InjectSecretsFromVault(references, injectFunc)
+		err := injector.InjectSecretsFromVault(references, injectFunc)
 		assert.EqualError(t, err, "path not found: secret/data/supersecret")
 	})
 
 	t.Run("incorrect kv2 path", func(t *testing.T) {
-		// TODO: fix race condition
-		// t.Parallel()
+		t.Parallel()
 
 		references := map[string]string{
 			"SECRET": "vault:secret/get/data#data",
@@ -156,7 +154,7 @@ func TestSecretInjector(t *testing.T) {
 			results[key] = value
 		}
 
-		err = injector.InjectSecretsFromVault(references, injectFunc)
+		err := injector.InjectSecretsFromVault(references, injectFunc)
 		assert.EqualError(t, err, "path not found: secret/get/data")
 	})
 }
@@ -194,8 +192,7 @@ func TestSecretInjectorFromPath(t *testing.T) {
 	injector := NewSecretInjector(Config{}, client, nil, logrus.New())
 
 	t.Run("success", func(t *testing.T) {
-		// TODO: fix race condition
-		// t.Parallel()
+		t.Parallel()
 
 		paths := "secret/data/account1"
 
@@ -206,7 +203,7 @@ func TestSecretInjectorFromPath(t *testing.T) {
 			results[key] = value
 		}
 
-		err = injector.InjectSecretsFromVaultPath(paths, injectFunc)
+		err := injector.InjectSecretsFromVaultPath(paths, injectFunc)
 		require.NoError(t, err)
 
 		assert.Equal(t, map[string]string{
@@ -216,8 +213,7 @@ func TestSecretInjectorFromPath(t *testing.T) {
 	})
 
 	t.Run("success multiple paths", func(t *testing.T) {
-		// TODO: fix race condition
-		// t.Parallel()
+		t.Parallel()
 
 		paths := "secret/data/account1,secret/data/account2"
 		results := map[string]string{}
@@ -227,7 +223,7 @@ func TestSecretInjectorFromPath(t *testing.T) {
 			results[key] = value
 		}
 
-		err = injector.InjectSecretsFromVaultPath(paths, injectFunc)
+		err := injector.InjectSecretsFromVaultPath(paths, injectFunc)
 		require.NoError(t, err)
 
 		assert.Equal(t, map[string]string{
@@ -239,8 +235,7 @@ func TestSecretInjectorFromPath(t *testing.T) {
 	})
 
 	t.Run("incorrect kv2 path", func(t *testing.T) {
-		// TODO: fix race condition
-		// t.Parallel()
+		t.Parallel()
 
 		paths := "secret/data/doesnotexist"
 
@@ -250,7 +245,7 @@ func TestSecretInjectorFromPath(t *testing.T) {
 			results[key] = value
 		}
 
-		err = injector.InjectSecretsFromVaultPath(paths, injectFunc)
+		err := injector.InjectSecretsFromVaultPath(paths, injectFunc)
 		assert.EqualError(t, err, "path not found: secret/data/doesnotexist")
 
 		assert.Equal(t, map[string]string{}, results)

--- a/pkg/webhook/configmap.go
+++ b/pkg/webhook/configmap.go
@@ -68,7 +68,7 @@ func (mw *MutatingWebhook) MutateConfigMap(configMap *corev1.ConfigMap, vaultCon
 			binaryData := map[string]string{
 				key: string(value),
 			}
-			err := mw.mutateConfigMapBinaryData(configMap, binaryData, secretInjector)
+			err := mw.mutateConfigMapBinaryData(configMap, binaryData, &secretInjector)
 			if err != nil {
 				return err
 			}
@@ -78,7 +78,7 @@ func (mw *MutatingWebhook) MutateConfigMap(configMap *corev1.ConfigMap, vaultCon
 	return nil
 }
 
-func (mw *MutatingWebhook) mutateConfigMapBinaryData(configMap *corev1.ConfigMap, data map[string]string, secretInjector injector.SecretInjector) error {
+func (mw *MutatingWebhook) mutateConfigMapBinaryData(configMap *corev1.ConfigMap, data map[string]string, secretInjector *injector.SecretInjector) error {
 	mapData, err := secretInjector.GetDataFromVault(data)
 	if err != nil {
 		return err

--- a/pkg/webhook/object.go
+++ b/pkg/webhook/object.go
@@ -74,7 +74,7 @@ func sliceIterator(s []interface{}) iterator {
 	return c
 }
 
-func traverseObject(o interface{}, secretInjector injector.SecretInjector) error {
+func traverseObject(o interface{}, secretInjector *injector.SecretInjector) error {
 	var iterator iterator
 
 	switch value := o.(type) {
@@ -135,5 +135,5 @@ func (mw *MutatingWebhook) MutateObject(object *unstructured.Unstructured, vault
 	}
 	secretInjector := injector.NewSecretInjector(config, vaultClient, nil, logger)
 
-	return traverseObject(object.Object, secretInjector)
+	return traverseObject(object.Object, &secretInjector)
 }

--- a/pkg/webhook/secret.go
+++ b/pkg/webhook/secret.go
@@ -111,13 +111,13 @@ func (mw *MutatingWebhook) MutateSecret(secret *corev1.Secret, vaultConfig Vault
 		if err != nil {
 			return errors.Wrap(err, "unmarshal dockerconfig json failed")
 		}
-		err = mw.mutateDockerCreds(secret, &dc, secretInjector)
+		err = mw.mutateDockerCreds(secret, &dc, &secretInjector)
 		if err != nil {
 			return errors.Wrap(err, "mutate dockerconfig json failed")
 		}
 	}
 
-	err = mw.mutateSecretData(secret, secretInjector)
+	err = mw.mutateSecretData(secret, &secretInjector)
 	if err != nil {
 		return errors.Wrap(err, "mutate generic secret failed")
 	}
@@ -125,7 +125,7 @@ func (mw *MutatingWebhook) MutateSecret(secret *corev1.Secret, vaultConfig Vault
 	return nil
 }
 
-func (mw *MutatingWebhook) mutateDockerCreds(secret *corev1.Secret, dc *dockerCredentials, secretInjector injector.SecretInjector) error {
+func (mw *MutatingWebhook) mutateDockerCreds(secret *corev1.Secret, dc *dockerCredentials, secretInjector *injector.SecretInjector) error {
 	assembled := dockerCredentials{Auths: map[string]dockerAuthConfig{}}
 
 	for key, creds := range dc.Auths {
@@ -174,7 +174,7 @@ func (mw *MutatingWebhook) mutateDockerCreds(secret *corev1.Secret, dc *dockerCr
 	return nil
 }
 
-func (mw *MutatingWebhook) mutateSecretData(secret *corev1.Secret, secretInjector injector.SecretInjector) error {
+func (mw *MutatingWebhook) mutateSecretData(secret *corev1.Secret, secretInjector *injector.SecretInjector) error {
 	convertedData := make(map[string]string, len(secret.Data))
 
 	for k := range secret.Data {


### PR DESCRIPTION
## Overview

Resolves #32  


## Notes for reviewer

Adds `RWMutex` on maps to protect against concurrent map read/write ops. 

<!-- Anything the reviewer should know? -->
