### PR TITLE
Added certLifetime and caLifetime setting and values

### DIFF
--- a/deploy/charts/vault-secrets-webhook/README.md
+++ b/deploy/charts/vault-secrets-webhook/README.md
@@ -142,6 +142,8 @@ The following tables lists configurable parameters of the vault-secrets-webhook 
 | podDisruptionBudget.minAvailable   | represents the number of Pods that must be available (integer or percentage)  | `1`                                                      |
 | podDisruptionBudget.maxUnavailable | represents the number of Pods that can be unavailable (integer or percentage) | ` `                                                      |
 | certificate.generate               | should a new CA and TLS certificate be generated for the webhook              | `true`                                                   |
+| certificate.caLifespan             | the number of days from the creation of the CA certificate until it expires   | `3650`                                                   |
+| certificate.certLifespan           | the number of days from the creation of the TLS certificate until it expires  | `365`                                                    |
 | certificate.useCertManager         | should request cert-manager for getting a new CA and TLS certificate          | `false`                                                  |
 | certificate.servingCertificate     | should use an already externally defined Certificate by cert-manager          | `null`                                                   |
 | certificate.ca.crt                 | Base64 encoded CA certificate                                                 | ``                                                       |

--- a/deploy/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/deploy/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -2,12 +2,12 @@
 {{- $tlsKey := "" }}
 {{- $caCrt := "" }}
 {{- if .Values.certificate.generate }}
-{{- $ca := genCA "svc-cat-ca" 3650 }}
+{{- $ca := genCA "svc-cat-ca" .Values.certificate.caLifespan }}
 {{- $svcName := include "vault-secrets-webhook.fullname" . }}
 {{- $cn := printf "%s.%s.svc" $svcName .Release.Namespace }}
 {{- $altName1 := printf "%s.cluster.local" $cn }}
 {{- $altName2 := printf "%s" $cn }}
-{{- $server := genSignedCert $cn nil (concat (list $altName1 $altName2) .Values.certificate.extraAltNames) 365 $ca }}
+{{- $server := genSignedCert $cn nil (concat (list $altName1 $altName2) .Values.certificate.extraAltNames) .Values.certificate.certLifespan $ca }}
 {{- $tlsCrt = b64enc $server.Cert }}
 {{- $tlsKey = b64enc $server.Key }}
 {{- $caCrt =  b64enc $ca.Cert }}

--- a/deploy/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/deploy/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -2,12 +2,12 @@
 {{- $tlsKey := "" }}
 {{- $caCrt := "" }}
 {{- if .Values.certificate.generate }}
-{{- $ca := genCA "svc-cat-ca" .Values.certificate.caLifespan }}
+{{- $ca := genCA "svc-cat-ca" (.Values.certificate.caLifespan | int) }}
 {{- $svcName := include "vault-secrets-webhook.fullname" . }}
 {{- $cn := printf "%s.%s.svc" $svcName .Release.Namespace }}
 {{- $altName1 := printf "%s.cluster.local" $cn }}
 {{- $altName2 := printf "%s" $cn }}
-{{- $server := genSignedCert $cn nil (concat (list $altName1 $altName2) .Values.certificate.extraAltNames) .Values.certificate.certLifespan $ca }}
+{{- $server := genSignedCert $cn nil (concat (list $altName1 $altName2) .Values.certificate.extraAltNames) (.Values.certificate.certLifespan | int) $ca }}
 {{- $tlsCrt = b64enc $server.Cert }}
 {{- $tlsKey = b64enc $server.Key }}
 {{- $caCrt =  b64enc $ca.Cert }}

--- a/deploy/charts/vault-secrets-webhook/values.yaml
+++ b/deploy/charts/vault-secrets-webhook/values.yaml
@@ -18,6 +18,8 @@ certificate:
     crt:
   extraAltNames: []
   # use extra names if you want use the webhook via an ingress or a loadbalancer
+  caLifespan: 3650
+  certLifespan: 365
 
 image:
   repository: ghcr.io/bank-vaults/vault-secrets-webhook


### PR DESCRIPTION
## Overview
This change will allow us to adjust the certificate lifespan for our internally hosted vault servers. Defaults persist at 10 years for the CA and 1 year for the certificate.

Upstreaming this patch will allow others to make this adjustment too.

There is no issue raised that is aligned to this PR.

## Notes for reviewer

We have used this "tweak" internally for some time, albeit with fixed values. I'm afraid I don't know how or where to add a test for this change, but am happy to build one/some if someone is willing to help me do it.

(Resubmit of #187 with correct committer/author values)