### PR TITLE
fix: Only add SC capabilities if vault templating is used

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.2.1@sha256:8879a398dedf0aadaacfbd332b29ff2f84bc39ae6d4e9c0a1109db27ac5ba012 AS xx
+FROM --platform=linux/amd64 tonistiigi/xx:1.2.1@sha256:8879a398dedf0aadaacfbd332b29ff2f84bc39ae6d4e9c0a1109db27ac5ba012 AS xx
 
-FROM --platform=$BUILDPLATFORM golang:1.21.3-alpine3.18@sha256:926f7f7e1ab8509b4e91d5ec6d5916ebb45155b0c8920291ba9f361d65385806 AS builder
+FROM --platform=linux/amd64 golang:1.21.3-alpine3.18@sha256:926f7f7e1ab8509b4e91d5ec6d5916ebb45155b0c8920291ba9f361d65385806 AS builder
 
 COPY --from=xx / /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM --platform=linux/amd64 tonistiigi/xx:1.2.1@sha256:8879a398dedf0aadaacfbd332b29ff2f84bc39ae6d4e9c0a1109db27ac5ba012 AS xx
+FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.2.1@sha256:8879a398dedf0aadaacfbd332b29ff2f84bc39ae6d4e9c0a1109db27ac5ba012 AS xx
 
-FROM --platform=linux/amd64 golang:1.21.3-alpine3.18@sha256:926f7f7e1ab8509b4e91d5ec6d5916ebb45155b0c8920291ba9f361d65385806 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.21.3-alpine3.18@sha256:926f7f7e1ab8509b4e91d5ec6d5916ebb45155b0c8920291ba9f361d65385806 AS builder
 
 COPY --from=xx / /
 

--- a/pkg/webhook/pod.go
+++ b/pkg/webhook/pod.go
@@ -870,17 +870,6 @@ func getBaseSecurityContext(podSecurityContext *corev1.PodSecurityContext, vault
 		context.RunAsUser = podSecurityContext.RunAsUser
 	}
 
-	// If we are using an agent, add required capabilities
-	if vaultConfig.UseAgent || vaultConfig.CtConfigMap != "" {
-		context.Capabilities.Add = []corev1.Capability{
-			"CHOWN",
-			"SETFCAP",
-			"SETGID",
-			"SETPCAP",
-			"SETUID",
-		}
-	}
-
 	// Although it could explicitly be set to false,
 	// the behavior of false and unset are the same
 	if vaultConfig.RunAsNonRoot {

--- a/pkg/webhook/pod.go
+++ b/pkg/webhook/pod.go
@@ -859,13 +859,7 @@ func getBaseSecurityContext(podSecurityContext *corev1.PodSecurityContext, vault
 		AllowPrivilegeEscalation: &vaultConfig.PspAllowPrivilegeEscalation,
 		ReadOnlyRootFilesystem:   &vaultConfig.ReadOnlyRootFilesystem,
 		Capabilities: &corev1.Capabilities{
-			Add: []corev1.Capability{
-				"CHOWN",
-				"SETFCAP",
-				"SETGID",
-				"SETPCAP",
-				"SETUID",
-			},
+			Add: []corev1.Capability{},
 			Drop: []corev1.Capability{
 				"ALL",
 			},
@@ -874,6 +868,17 @@ func getBaseSecurityContext(podSecurityContext *corev1.PodSecurityContext, vault
 
 	if podSecurityContext != nil && podSecurityContext.RunAsUser != nil {
 		context.RunAsUser = podSecurityContext.RunAsUser
+	}
+
+	// If we are using an agent, add required capabilities
+	if vaultConfig.UseAgent || vaultConfig.CtConfigMap != "" {
+		context.Capabilities.Add = []corev1.Capability{
+			"CHOWN",
+			"SETFCAP",
+			"SETGID",
+			"SETPCAP",
+			"SETUID",
+		}
 	}
 
 	// Although it could explicitly be set to false,

--- a/pkg/webhook/pod_test.go
+++ b/pkg/webhook/pod_test.go
@@ -514,13 +514,7 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 		ReadOnlyRootFilesystem:   &vaultConfig.ReadOnlyRootFilesystem,
 		AllowPrivilegeEscalation: &vaultConfig.PspAllowPrivilegeEscalation,
 		Capabilities: &corev1.Capabilities{
-			Add: []corev1.Capability{
-				"CHOWN",
-				"SETFCAP",
-				"SETGID",
-				"SETPCAP",
-				"SETUID",
-			},
+			Add: []corev1.Capability{},
 			Drop: []corev1.Capability{
 				"ALL",
 			},


### PR DESCRIPTION
## Overview

If applied, this PR should make the webhook only include the current default SC capabilities when using Vault Agent Templating.
Thus, we should be able to fix pods not starting if running under restricted environments (like OpenShift).

Fixes https://github.com/bank-vaults/vault-secrets-webhook/issues/244

## Notes for reviewer

N/A
