### PR TITLE
certmanager: solve CannotRegenerateKey

### DIFF
--- a/deploy/charts/vault-secrets-webhook/templates/webhook-cert-manager.yaml
+++ b/deploy/charts/vault-secrets-webhook/templates/webhook-cert-manager.yaml
@@ -35,7 +35,8 @@ spec:
     name: {{ include "vault-secrets-webhook.selfSignedIssuer" . }}
   commonName: "ca.vault-secrets-webhook.cert-manager"
   isCA: true
-
+  privateKey:
+    rotationPolicy: Always
 ---
 
 # Create an Issuer that uses the above generated CA certificate to issue certs
@@ -80,5 +81,6 @@ spec:
   {{- range .Values.certificate.extraAltNames }}
   - {{ . }}
   {{- end }}
-
+  privateKey:
+    rotationPolicy: Always
 {{- end }}


### PR DESCRIPTION
## Overview

`CertManager` might throw a warning with the current Helm chart because the `.spec.privateKey.rotationPolicy` is unset.

This will set the field to `Always` which allows rotation in case there is a need for, which can resolve potential issues of an invalid cert.

For context, this is what certmanager also recommends: https://cert-manager.io/docs/usage/certificate/

