### PR TITLE
chore: add options for resource requests for vault-agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ build: ## Build binary
 
 .PHONY: container-image
 container-image: ## Build container image
-	docker build -t ${CONTAINER_IMAGE_REF} .
+	docker build -t ${CONTAINER_IMAGE_REF} . --platform linux/amd64
 
 .PHONY: helm-chart
 helm-chart: ## Build Helm chart

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bank-vaults/vault-secrets-webhook
 
-go 1.21.1
+go 1.21
 
 require (
 	emperror.dev/errors v0.8.1

--- a/pkg/webhook/config.go
+++ b/pkg/webhook/config.go
@@ -64,8 +64,10 @@ type VaultConfig struct {
 	AgentOnce                     bool
 	AgentShareProcess             bool
 	AgentShareProcessDefault      string
-	AgentCPU                      resource.Quantity
-	AgentMemory                   resource.Quantity
+	AgentCPULimit                 resource.Quantity
+	AgentMemoryLimit              resource.Quantity
+	AgentCPURequest               resource.Quantity
+	AgentMemoryRequest            resource.Quantity
 	AgentImage                    string
 	AgentImagePullPolicy          corev1.PullPolicy
 	AgentEnvVariables             string
@@ -318,16 +320,28 @@ func parseVaultConfig(obj metav1.Object, ar *model.AdmissionReview) VaultConfig 
 		vaultConfig.AgentOnce = false
 	}
 
-	if val, err := resource.ParseQuantity(annotations["vault.security.banzaicloud.io/vault-agent-cpu"]); err == nil {
-		vaultConfig.AgentCPU = val
+	if val, err := resource.ParseQuantity(annotations["vault.security.banzaicloud.io/vault-agent-cpu-limit"]); err == nil {
+		vaultConfig.AgentCPULimit = val
 	} else {
-		vaultConfig.AgentCPU = resource.MustParse("100m")
+		vaultConfig.AgentCPULimit = resource.MustParse("100m")
 	}
 
-	if val, err := resource.ParseQuantity(annotations["vault.security.banzaicloud.io/vault-agent-memory"]); err == nil {
-		vaultConfig.AgentMemory = val
+	if val, err := resource.ParseQuantity(annotations["vault.security.banzaicloud.io/vault-agent-memory-limit"]); err == nil {
+		vaultConfig.AgentMemoryLimit = val
 	} else {
-		vaultConfig.AgentMemory = resource.MustParse("128Mi")
+		vaultConfig.AgentMemoryLimit = resource.MustParse("128Mi")
+	}
+
+	if val, err := resource.ParseQuantity(annotations["vault.security.banzaicloud.io/vault-agent-cpu-request"]); err == nil {
+		vaultConfig.AgentCPURequest = val
+	} else {
+		vaultConfig.AgentCPURequest = resource.MustParse("100m")
+	}
+
+	if val, err := resource.ParseQuantity(annotations["vault.security.banzaicloud.io/vault-agent-memory-request"]); err == nil {
+		vaultConfig.AgentMemoryRequest = val
+	} else {
+		vaultConfig.AgentMemoryRequest = resource.MustParse("128Mi")
 	}
 
 	if val, ok := annotations["vault.security.banzaicloud.io/vault-agent-share-process-namespace"]; ok {

--- a/pkg/webhook/pod.go
+++ b/pkg/webhook/pod.go
@@ -845,8 +845,12 @@ func getAgentContainers(originalContainers []corev1.Container, podSecurityContex
 		VolumeMounts:    containerVolMounts,
 		Resources: corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    vaultConfig.AgentCPU,
-				corev1.ResourceMemory: vaultConfig.AgentMemory,
+				corev1.ResourceCPU:    vaultConfig.AgentCPULimit,
+				corev1.ResourceMemory: vaultConfig.AgentMemoryLimit,
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    vaultConfig.AgentCPURequest,
+				corev1.ResourceMemory: vaultConfig.AgentMemoryRequest,
 			},
 		},
 	})

--- a/pkg/webhook/pod_test.go
+++ b/pkg/webhook/pod_test.go
@@ -1023,12 +1023,12 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 							Args:            []string{"agent", "-config", "/vault/config/config.hcl"},
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("200m"),
-									corev1.ResourceMemory: resource.MustParse("256Mi"),
-								},
-								Requests: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("500m"),
 									corev1.ResourceMemory: resource.MustParse("384Mi"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("200m"),
+									corev1.ResourceMemory: resource.MustParse("256Mi"),
 								},
 							},
 							Env: []corev1.EnvVar{

--- a/pkg/webhook/pod_test.go
+++ b/pkg/webhook/pod_test.go
@@ -999,8 +999,10 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 					ConfigfilePath:                "/vault/secrets",
 					Addr:                          "test",
 					SkipVerify:                    false,
-					AgentCPU:                      resource.MustParse("50m"),
-					AgentMemory:                   resource.MustParse("128Mi"),
+					AgentCPURequest:               resource.MustParse("200m"),
+					AgentMemoryRequest:            resource.MustParse("256Mi"),
+					AgentCPULimit:                 resource.MustParse("500m"),
+					AgentMemoryLimit:              resource.MustParse("384Mi"),
 					AgentImage:                    "hashicorp/vault:latest",
 					AgentImagePullPolicy:          "IfNotPresent",
 					ServiceAccountTokenVolumeName: "/var/run/secrets/kubernetes.io/serviceaccount",
@@ -1021,8 +1023,12 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 							Args:            []string{"agent", "-config", "/vault/config/config.hcl"},
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("50m"),
-									corev1.ResourceMemory: resource.MustParse("128Mi"),
+									corev1.ResourceCPU:    resource.MustParse("200m"),
+									corev1.ResourceMemory: resource.MustParse("256Mi"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("500m"),
+									corev1.ResourceMemory: resource.MustParse("384Mi"),
 								},
 							},
 							Env: []corev1.EnvVar{


### PR DESCRIPTION
Currently the vault-agent takes a resource for requests and limits combined but in usage we see that startup usage is high and ongoing usage is low so we are faced with either large amounts of wasted resources across a cluster or a risk of OOM kills on startup. This PR will just allow requests and limits to be defined independently of each other