### PR TITLE
chore: add options for resource requests for vault-agent

### DIFF
--- a/pkg/webhook/config.go
+++ b/pkg/webhook/config.go
@@ -320,23 +320,23 @@ func parseVaultConfig(obj metav1.Object, ar *model.AdmissionReview) VaultConfig 
 		vaultConfig.AgentOnce = false
 	}
 
-    // This is done to preserve backwards compatibility with vault-agent-cpu
-    if val, err := resource.ParseQuantity(annotations["vault.security.banzaicloud.io/vault-agent-cpu"]); err == nil {
-    	vaultConfig.AgentCPULimit = val
-    } else if val, err := resource.ParseQuantity(annotations["vault.security.banzaicloud.io/vault-agent-cpu-limit"]); err == nil {
-    	vaultConfig.AgentCPULimit = val
-    } else {
-    	vaultConfig.AgentCPULimit = resource.MustParse("100m")
-    }
+	// This is done to preserve backwards compatibility with vault-agent-cpu
+	if val, err := resource.ParseQuantity(annotations["vault.security.banzaicloud.io/vault-agent-cpu"]); err == nil {
+		vaultConfig.AgentCPULimit = val
+	} else if val, err := resource.ParseQuantity(annotations["vault.security.banzaicloud.io/vault-agent-cpu-limit"]); err == nil {
+		vaultConfig.AgentCPULimit = val
+	} else {
+		vaultConfig.AgentCPULimit = resource.MustParse("100m")
+	}
 
-    // This is done to preserve backwards compatibility with vault-agent-memory
-    if val, err := resource.ParseQuantity(annotations["vault.security.banzaicloud.io/vault-agent-memory"]); err == nil {
-    	vaultConfig.AgentMemoryLimit = val
-    } else if val, err := resource.ParseQuantity(annotations["vault.security.banzaicloud.io/vault-agent-memory-limit"]); err == nil {
-    	vaultConfig.AgentMemoryLimit = val
-    } else {
-    	vaultConfig.AgentMemoryLimit = resource.MustParse("128Mi")
-    }
+	// This is done to preserve backwards compatibility with vault-agent-memory
+	if val, err := resource.ParseQuantity(annotations["vault.security.banzaicloud.io/vault-agent-memory"]); err == nil {
+		vaultConfig.AgentMemoryLimit = val
+	} else if val, err := resource.ParseQuantity(annotations["vault.security.banzaicloud.io/vault-agent-memory-limit"]); err == nil {
+		vaultConfig.AgentMemoryLimit = val
+	} else {
+		vaultConfig.AgentMemoryLimit = resource.MustParse("128Mi")
+	}
 
 	if val, err := resource.ParseQuantity(annotations["vault.security.banzaicloud.io/vault-agent-cpu-request"]); err == nil {
 		vaultConfig.AgentCPURequest = val

--- a/pkg/webhook/pod.go
+++ b/pkg/webhook/pod.go
@@ -845,8 +845,12 @@ func getAgentContainers(originalContainers []corev1.Container, podSecurityContex
 		VolumeMounts:    containerVolMounts,
 		Resources: corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    vaultConfig.AgentCPU,
-				corev1.ResourceMemory: vaultConfig.AgentMemory,
+				corev1.ResourceCPU:    vaultConfig.AgentCPULimit,
+				corev1.ResourceMemory: vaultConfig.AgentMemoryLimit,
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    vaultConfig.AgentCPURequest,
+				corev1.ResourceMemory: vaultConfig.AgentMemoryRequest,
 			},
 		},
 	})

--- a/pkg/webhook/pod_test.go
+++ b/pkg/webhook/pod_test.go
@@ -999,8 +999,10 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 					ConfigfilePath:                "/vault/secrets",
 					Addr:                          "test",
 					SkipVerify:                    false,
-					AgentCPU:                      resource.MustParse("50m"),
-					AgentMemory:                   resource.MustParse("128Mi"),
+					AgentCPURequest:               resource.MustParse("200m"),
+					AgentMemoryRequest:            resource.MustParse("256Mi"),
+					AgentCPULimit:                 resource.MustParse("500m"),
+					AgentMemoryLimit:              resource.MustParse("384Mi"),
 					AgentImage:                    "hashicorp/vault:latest",
 					AgentImagePullPolicy:          "IfNotPresent",
 					ServiceAccountTokenVolumeName: "/var/run/secrets/kubernetes.io/serviceaccount",
@@ -1021,8 +1023,12 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 							Args:            []string{"agent", "-config", "/vault/config/config.hcl"},
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("50m"),
-									corev1.ResourceMemory: resource.MustParse("128Mi"),
+									corev1.ResourceCPU:    resource.MustParse("500m"),
+									corev1.ResourceMemory: resource.MustParse("384Mi"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("200m"),
+									corev1.ResourceMemory: resource.MustParse("256Mi"),
 								},
 							},
 							Env: []corev1.EnvVar{


### PR DESCRIPTION
Currently the vault-agent takes a resource for requests and limits combined but in usage we see that startup usage is high and ongoing usage is low so we are faced with either large amounts of wasted resources across a cluster or a risk of OOM kills on startup. This PR will just allow requests and limits to be defined independently of each other