### PR TITLE
fix: prevent recurring helm install/upgrade creating a loop deleting caBundle, when certManager is enabled

### DIFF
--- a/deploy/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/deploy/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -126,7 +126,9 @@ webhooks:
       name: {{ template "vault-secrets-webhook.fullname" . }}
       path: /pods
     {{- end }}
+    {{- if not .Values.certificate.useCertManager }}
     caBundle: {{ $caCrt }}
+    {{- end }}
   rules:
   - operations:
     - CREATE
@@ -188,7 +190,9 @@ webhooks:
       name: {{ template "vault-secrets-webhook.fullname" . }}
       path: /secrets
     {{- end }}
+    {{- if not .Values.certificate.useCertManager }}
     caBundle: {{ $caCrt }}
+    {{- end }}
   rules:
   - operations:
     - CREATE
@@ -256,7 +260,9 @@ webhooks:
       name: {{ template "vault-secrets-webhook.fullname" . }}
       path: /configmaps
     {{- end }}
+    {{- if not .Values.certificate.useCertManager }}
     caBundle: {{ $caCrt }}
+    {{- end }}
   rules:
     - operations:
         - CREATE
@@ -321,7 +327,9 @@ webhooks:
       name: {{ template "vault-secrets-webhook.fullname" . }}
       path: /objects
     {{- end }}
+    {{- if not .Values.certificate.useCertManager }}
     caBundle: {{ $caCrt }}
+    {{- end }}
   rules:
   - operations:
     - CREATE


### PR DESCRIPTION
## Overview

Whenever cert-manager is used to generate the certificate and set the caBundle in the webhook, on recurring executions of helm the caBundle is deleted, and later re-added.

This PR disables handling of the caBundle property of the webhook in case cert-manager is being used, to prevent this issue.
