### PR TITLE
fix: vault-log-level overwritten in pods

### DIFF
--- a/pkg/webhook/pod.go
+++ b/pkg/webhook/pod.go
@@ -358,8 +358,7 @@ func (mw *MutatingWebhook) mutateContainers(ctx context.Context, containers []co
 			})
 		}
 
-		ok := isLogLevelSet(container.Env)
-		if !ok && vaultConfig.LogLevel != "" {
+		if !isLogLevelSet(container.Env) && vaultConfig.LogLevel != "" {
 			container.Env = append(container.Env, []corev1.EnvVar{
 				{
 					Name:  "VAULT_LOG_LEVEL",

--- a/pkg/webhook/pod.go
+++ b/pkg/webhook/pod.go
@@ -917,6 +917,8 @@ func getConfigMapForVaultAgent(pod *corev1.Pod, vaultConfig VaultConfig) *corev1
 	}
 }
 
+// isLogLevelSet checks if the VAULT_LOG_LEVEL environment variable
+// has already been set in the container, so it doesn't get overridden.
 func isLogLevelSet(envVars []corev1.EnvVar) bool {
 	for _, envVar := range envVars {
 		if envVar.Name == "VAULT_LOG_LEVEL" {

--- a/pkg/webhook/pod.go
+++ b/pkg/webhook/pod.go
@@ -358,7 +358,8 @@ func (mw *MutatingWebhook) mutateContainers(ctx context.Context, containers []co
 			})
 		}
 
-		if vaultConfig.LogLevel != "" {
+		ok := isLogLevelSet(container.Env)
+		if !ok && vaultConfig.LogLevel != "" {
 			container.Env = append(container.Env, []corev1.EnvVar{
 				{
 					Name:  "VAULT_LOG_LEVEL",
@@ -915,4 +916,13 @@ func getConfigMapForVaultAgent(pod *corev1.Pod, vaultConfig VaultConfig) *corev1
 			"config.hcl": fmt.Sprintf(vaultAgentConfig, vaultConfig.VaultNamespace, vaultConfig.Path, vaultConfig.Role),
 		},
 	}
+}
+
+func isLogLevelSet(envVars []corev1.EnvVar) bool {
+	for _, envVar := range envVars {
+		if envVar.Name == "VAULT_LOG_LEVEL" {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/webhook/pod_test.go
+++ b/pkg/webhook/pod_test.go
@@ -467,7 +467,7 @@ func Test_mutatingWebhook_mutateContainers(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Mutating does not change pods log level if it is already set in the container",
+			name: "Mutate will not change the containers log level if was already set",
 			fields: fields{
 				k8sClient: fake.NewSimpleClientset(),
 				registry: &MockRegistry{

--- a/pkg/webhook/pod_test.go
+++ b/pkg/webhook/pod_test.go
@@ -467,7 +467,7 @@ func Test_mutatingWebhook_mutateContainers(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Mutate will not change the containers log level if was already set",
+			name: "Mutate will not change the containers log level if it was already set",
 			fields: fields{
 				k8sClient: fake.NewSimpleClientset(),
 				registry: &MockRegistry{


### PR DESCRIPTION

## Overview

- Wrote a test to showcase the problem mentioned in the issue.
- Added a check, if `VAULT_LOG_LEVEL` is set in the container, it remains unchanged after mutation. However, if it isn't, and the `vaultConfig` contains the relevant field, the value is set accordingly.

Fixes #290
