### PR TITLE
fix: handle _json_key .dockerconfigjson data

### DIFF
--- a/pkg/webhook/secret.go
+++ b/pkg/webhook/secret.go
@@ -72,6 +72,7 @@ func secretNeedsMutation(secret *corev1.Secret) (bool, error) {
 					if hasVaultPrefix(auth) {
 						return true, nil
 					}
+
 				case map[string]interface{}:
 					// get sub-keys from the auth field
 					authMap, ok := creds.Auth.(map[string]interface{})
@@ -223,10 +224,10 @@ func handleAuthString(auth string) (string, string, error) {
 
 	// if the auth string is a JSON key,
 	// don't split and use it as is
-	ok := IsJSONKey(auth)
-	if ok {
+	if IsJSONKey(auth) {
 		return auth, "", nil
 	}
+
 	// if none of the above, the auth string can still be a valid vault path
 	if validVaultPath(auth) {
 		return auth, "", nil

--- a/pkg/webhook/secret.go
+++ b/pkg/webhook/secret.go
@@ -79,6 +79,7 @@ func secretNeedsMutation(secret *corev1.Secret) (bool, error) {
 					if !ok {
 						return false, errors.New("invalid auth type")
 					}
+
 					// check if any of the sub-keys have a vault prefix
 					for _, v := range authMap {
 						if hasVaultPrefix(v.(string)) {
@@ -224,7 +225,7 @@ func handleAuthString(auth string) (string, string, error) {
 
 	// if the auth string is a JSON key,
 	// don't split and use it as is
-	if IsJSONKey(auth) {
+	if isJSONKey(auth) {
 		return auth, "", nil
 	}
 
@@ -236,7 +237,7 @@ func handleAuthString(auth string) (string, string, error) {
 	return "", "", errors.New("invalid auth string")
 }
 
-func IsJSONKey(auth string) bool {
+func isJSONKey(auth string) bool {
 	var authMap map[string]interface{}
 	err := json.Unmarshal([]byte(auth), &authMap)
 	if err != nil {

--- a/pkg/webhook/secret.go
+++ b/pkg/webhook/secret.go
@@ -253,7 +253,6 @@ func isJSONKey(auth string) bool {
 	return false
 }
 
-// hasVaultPrefix checks if the given string is a valid vault path
 func validVaultPath(auth string) bool {
 	re := regexp.MustCompile(`^(vault:secret)(\/\w+)+(#.+)`)
 	match := re.MatchString(auth)


### PR DESCRIPTION
## Overview

- Made the `Auth` field of type `interface { }`, because this way the program can handle a `_json_key` if it is received under the `auth` key of a `.dockerconfigjson`.
-  I left the username, password splitting case as it was, and added a check for `_json_key` and another check, if a vault path is received upfront at the `auth` key.
- If we have sub-keys under the `auth` field, we can assume that a `_json_key` has been passed.
- if a vault path is passed upfront I used a regex to verify it's format.

Fixes #81 

## Notes for reviewers

- I tested the solution with these 3 `dockerconfigjson` secrets. 

```yaml
# test.yaml
# For this to work, run: vault kv put secret/test/mysql MYSQL_PASSWORD=3xtr3ms3cr3t
# Decoded structure of data:
# {
#   "auths": {
#     "https://myrepov": {
#       "auth": "vault:secret/data/test/mysql#MYSQL_PASSWORD"
#     }
#   }
# }

apiVersion: v1
kind: Secret
type: kubernetes.io/dockerconfigjson
metadata:
  name: broken-thing
  annotations:
    vault.security.banzaicloud.io/vault-skip-verify: "true"
data:
  .dockerconfigjson: eyJhdXRocyI6eyJodHRwczovL215cmVwb3YiOnsiYXV0aCI6ImRtRjFiSFE2YzJWamNtVjBMMlJoZEdFdmRHVnpkQzl0ZVhOeGJDTk5XVk5SVEY5UVFWTlRWMDlTUkE9PSJ9fX0=
```

```yaml
# test2.yaml
# Decoded structure of data:
# {
#   "auths": {
#     "https://myrepov": {
#       "auth": {
#         "type": "service_account",
#         "project_id": "fake-project"
#       }
#     }
#   }
# }

apiVersion: v1
kind: Secret
type: kubernetes.io/dockerconfigjson
metadata:
  name: docker-secret
  annotations:
    vault.security.banzaicloud.io/vault-skip-verify: "true"
data:
  .dockerconfigjson: eyJhdXRocyI6eyJodHRwczovL215cmVwb3YiOnsiYXV0aCI6eyJ0eXBlIjoic2VydmljZV9hY2NvdW50IiwicHJvamVjdF9pZCI6ImZha2UtcHJvamVjdCJ9fX19
```

```yaml
# test3.yaml
# For this to work, run: vault kv put secret/test/aws AWS_SECRET_ACCESS_KEY=s3cr3t
# Decoded structure:
# {
#   "auths": {
#     "https://myrepov": {
#       "auth": "vault:secret/data/test/aws#AWS_SECRET_ACCESS_KEY"
#     }
#   }
# }

apiVersion: v1
kind: Secret
type: kubernetes.io/dockerconfigjson
metadata:
  name: aws-key-secret
  annotations:
    vault.security.banzaicloud.io/vault-skip-verify: "true"
data:
  .dockerconfigjson: eyJhdXRocyI6eyJodHRwczovL215cmVwb3YiOnsiYXV0aCI6ImRtRjFiSFE2YzJWamNtVjBMMlJoZEdFdmRHVnpkQzloZDNNalFWZFRYMU5GUTFKRlZGOUJRME5GVTFOZlMwVloifX19
```