### PR TITLE
feat: support generic secret in docker auth

### DIFF
--- a/e2e/deploy/vault/vault.yaml
+++ b/e2e/deploy/vault/vault.yaml
@@ -146,6 +146,11 @@ spec:
           data:
             DOCKER_REPO_USER: dockerrepouser
             DOCKER_REPO_PASSWORD: dockerrepopassword
+            DOCKER_REPO_JSON_KEY: |
+              _json_key: {
+                "type": "service_account",
+                "project_id": "test"
+              }
       - type: kv
         path: secret/data/mysql
         data:

--- a/e2e/test/secret-docker-json-key.yaml
+++ b/e2e/test/secret-docker-json-key.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-secret-docker-json-key
+  annotations:
+    vault.security.banzaicloud.io/vault-addr: "https://vault.default.svc.cluster.local:8200"
+    vault.security.banzaicloud.io/vault-role: "default"
+    vault.security.banzaicloud.io/vault-tls-secret: vault-tls
+    # vault.security.banzaicloud.io/vault-skip-verify: "true"
+    vault.security.banzaicloud.io/vault-path: "kubernetes"
+type: kubernetes.io/dockerconfigjson
+stringData:
+  .dockerconfigjson: |
+    {
+        "auths": {
+            "https://index.docker.io/v1/": {
+                "auth": "dmF1bHQ6c2VjcmV0L2RhdGEvZG9ja2VycmVwbyNET0NLRVJfUkVQT19KU09OX0tFWQ=="
+            }
+        }
+    }

--- a/e2e/webhook_test.go
+++ b/e2e/webhook_test.go
@@ -113,16 +113,12 @@ func TestSecretValueInjection(t *testing.T) {
 			err := cfg.Client().Resources(cfg.Namespace()).Get(ctx, "test-secret-docker-json-key", cfg.Namespace(), &secret)
 			require.NoError(t, err)
 
-			type v1 struct {
+			type auth struct {
 				Auth string `json:"auth"`
 			}
 
-			type auths struct {
-				V1 v1 `json:"https://index.docker.io/v1/"`
-			}
-
 			type dockerconfig struct {
-				Auths auths `json:"auths"`
+				Auths map[string]auth `json:"auths"`
 			}
 
 			var dockerconfigjson dockerconfig
@@ -131,7 +127,7 @@ func TestSecretValueInjection(t *testing.T) {
 			require.NoError(t, err)
 
 			dockerrepoauth := base64.StdEncoding.EncodeToString([]byte("_json_key: {\n  \"type\": \"service_account\",\n  \"project_id\": \"test\"\n}\n"))
-			assert.Equal(t, dockerrepoauth, dockerconfigjson.Auths.V1.Auth)
+			assert.Equal(t, dockerrepoauth, dockerconfigjson.Auths["https://index.docker.io/v1/"].Auth)
 
 			return ctx
 		}).


### PR DESCRIPTION
## Overview

currently, the webhook only supports unwrapping the value of the auth key if it's in a specific `user:pass` format. this limitation prevents the webhook from working correctly for other valid formats of the auth value, e.g., `_json_key`. 