### PR TITLE
fix: Unable to deploy with cert-manager when certain options are set

### DIFF
--- a/deploy/charts/vault-secrets-webhook/templates/webhook-cert-manager.yaml
+++ b/deploy/charts/vault-secrets-webhook/templates/webhook-cert-manager.yaml
@@ -37,6 +37,9 @@ spec:
   isCA: true
   privateKey:
     rotationPolicy: Always
+  secretTemplate:
+    annotations:
+      vault.security.banzaicloud.io/mutate: skip
 ---
 
 # Create an Issuer that uses the above generated CA certificate to issue certs


### PR DESCRIPTION
This PR fixes a chicken and egg problem when mutatingwebhook set to Fail and Secret mutation is enabled, in which case  vault-secrets-webhook is not yet started (waiting for certificate) and cert-manager cannot issue the Certificate because the secret is blocked by the webhook created on install

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Fixes #(issue)

## Notes for reviewer

<!-- Anything the reviewer should know? -->
