### PR TITLE
fix: support raw environment variables in chart

### DIFF
--- a/deploy/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
+++ b/deploy/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
@@ -85,6 +85,9 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
+            {{- with .Values.envRaw }}
+            {{- . | toYaml | nindent 12 }}
+            {{- end}}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}

--- a/deploy/charts/vault-secrets-webhook/values.yaml
+++ b/deploy/charts/vault-secrets-webhook/values.yaml
@@ -103,6 +103,9 @@ env: {}
   ## -- Define remote log server for vault-env
   # VAULT_ENV_LOG_SERVER: ""
 
+# -- Raw extra environment variables
+envRaw: {}
+
 # -- Containers to run before the webhook containers are started
 initContainers: []
   # - name: init-myservice


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

This will allow passing environment variables from the pod status such as the host IP:

```yaml
envRaw:
  - name: HOST_IP
     valueFrom:
       fieldRef:
         apiVersion: v1
         fieldPath: status.hostIP
```

Fixes #(issue)

## Notes for reviewer

<!-- Anything the reviewer should know? -->
