### PR TITLE
fix: align default memory request and limit of vault-env

### DIFF
--- a/pkg/webhook/config.go
+++ b/pkg/webhook/config.go
@@ -418,7 +418,7 @@ func parseVaultConfig(obj metav1.Object, ar *model.AdmissionReview) VaultConfig 
 	if val, err := resource.ParseQuantity(viper.GetString("VAULT_ENV_MEMORY_REQUEST")); err == nil {
 		vaultConfig.EnvMemoryRequest = val
 	} else {
-		vaultConfig.EnvMemoryRequest = resource.MustParse("128Mi")
+		vaultConfig.EnvMemoryRequest = resource.MustParse("256Mi")
 	}
 
 	if val, err := resource.ParseQuantity(viper.GetString("VAULT_ENV_CPU_LIMIT")); err == nil {


### PR DESCRIPTION
## Overview

This PR aligns the vault-env memory request and limit values. The memory is a non-compressible resource and it is a best practice often enforced with policies using eg. Gatekeeper.
