### PR TITLE
feat: Add vault-env default requests and limits visible

### DIFF
--- a/deploy/charts/vault-secrets-webhook/values.yaml
+++ b/deploy/charts/vault-secrets-webhook/values.yaml
@@ -76,7 +76,7 @@ vaultEnv:
   tag: "v1.22.0"
 
 # -- Custom environment variables available to webhook
-env: {}
+env:
   ## -- Vault image
   # VAULT_IMAGE: hashicorp/vault:1.14.8
   # VAULT_CAPATH: /vault/tls
@@ -93,12 +93,12 @@ env: {}
   # VAULT_ROLE: ""
 
   ## -- Cpu requests and limits for init-containers vault-env and copy-vault-env
-  # VAULT_ENV_CPU_REQUEST: ""
-  # VAULT_ENV_CPU_LIMIT: ""
+  VAULT_ENV_CPU_REQUEST: "100m"
+  VAULT_ENV_CPU_LIMIT: "500m"
 
   ## -- Memory requests and limits for init-containers vault-env and copy-vault-env
-  # VAULT_ENV_MEMORY_REQUEST: ""
-  # VAULT_ENV_MEMORY_LIMIT: ""
+  VAULT_ENV_MEMORY_REQUEST: "256Mi"
+  VAULT_ENV_MEMORY_LIMIT: "256Mi"
 
   ## -- Define remote log server for vault-env
   # VAULT_ENV_LOG_SERVER: ""


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

We recently faced an incident in our Kubernetes environment related to the vault-secrets-webhook component.

After upgrading to a newer version, our workloads failed to get scheduled due to tight resource requests on our nodes. Upon investigation, we discovered that [this commit](https://github.com/bank-vaults/vault-secrets-webhook/commit/df97e40889ce4be7355910a45ece7f3be7843f08) introduced new default CPU and memory requests/limits to the vault-env.

This change was not mentioned in the release notes (it was somehow, but not clear), so it was invisible to us and caught that change during the upgrade (eg its not visible in argocd that these init containers values were changed). Since resource requests can have critical scheduling implications, it would be extremely helpful if such changes were explicitly documented.

Request:

Setting these resource requests/limits in the default values.yaml file of the Helm chart.
This would make them visible and overridable by users, reducing the risk of unexpected behavior.


## Notes for reviewer

<!-- Anything the reviewer should know? -->
