### PR TITLE
feat: Add new VAULT_SKIP_DEFAULT_ROLE behavior

### DIFF
--- a/deploy/charts/vault-secrets-webhook/values.yaml
+++ b/deploy/charts/vault-secrets-webhook/values.yaml
@@ -92,6 +92,9 @@ env: {}
   ## -- Define the webhook's role in Vault used for authentication, if not defined individually in resources by annotations
   # VAULT_ROLE: ""
 
+  ## -- Skip mutating for not POD resources with default role if does not set VAULT_ROLE
+  # VAULT_SKIP_DEFAULT_ROLE: "false"
+
   ## -- Cpu requests and limits for init-containers vault-env and copy-vault-env
   # VAULT_ENV_CPU_REQUEST: ""
   # VAULT_ENV_CPU_LIMIT: ""

--- a/pkg/webhook/config.go
+++ b/pkg/webhook/config.go
@@ -120,6 +120,10 @@ func parseVaultConfig(obj metav1.Object, ar *model.AdmissionReview) VaultConfig 
 			case *corev1.Pod:
 				vaultConfig.Role = p.Spec.ServiceAccountName
 			default:
+				if viper.GetBool("vault_skip_default_role") {
+					vaultConfig.Skip = true
+					return vaultConfig
+				}
 				vaultConfig.Role = "default"
 			}
 		}
@@ -476,6 +480,7 @@ func SetConfigDefaults() {
 	viper.SetDefault("vault_path", "kubernetes")
 	viper.SetDefault("vault_auth_method", "jwt")
 	viper.SetDefault("vault_role", "")
+	viper.SetDefault("vault_skip_default_role", "false")
 	viper.SetDefault("vault_tls_secret", "")
 	viper.SetDefault("vault_client_timeout", "10s")
 	viper.SetDefault("vault_agent", "false")


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
Fixes #(issue)
-->
In my practice, I often encounter charts where you can't add annotations to a secret, but in most cases, for PODs, this option is available. And secrets from secrets manifest are passes to POD and mutate there.

In order to be able to set "secrets FailurePolicy: Fail" when used in k8s cluster non annotated secrets, this commit was made.

## Notes for reviewer

<!-- Anything the reviewer should know? -->
In my practice I always use `vault.security.banzaicloud.io/vault-role` and not use "default" role (VAULT ROLE), but as i see, not any mechanism to prevent mutating for this cases;

PS: sorry my bad english and I am not GOlang programmer
