### PR TITLE
feat: new annotation - mutateContainers (choose containers for mutating)

### DIFF
--- a/e2e/test/deployment-mutate-containers.yaml
+++ b/e2e/test/deployment-mutate-containers.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment-mutate-containers
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: test-deployment-mutate-containers
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: test-deployment-mutate-containers
+      annotations:
+        vault.security.banzaicloud.io/vault-addr: "https://vault.default.svc.cluster.local:8200"
+        vault.security.banzaicloud.io/vault-role: "default"
+        vault.security.banzaicloud.io/vault-tls-secret: vault-tls
+        vault.security.banzaicloud.io/vault-path: "kubernetes"
+        vault.security.banzaicloud.io/mutate-containers: "alpine,redis"
+    spec:
+      initContainers:
+      - name: init-ubuntu
+        image: ubuntu
+        command: ["sh", "-c", "echo $AWS_SECRET_ACCESS_KEY && echo initContainers ready"]
+        env:
+        - name: AWS_SECRET_ACCESS_KEY
+          value: vault:secret/data/accounts/aws#AWS_SECRET_ACCESS_KEY
+        resources:
+          limits:
+            memory: "128Mi"
+            cpu: "100m"
+      containers:
+      - name: alpine
+        image: alpine
+        command: ["sh", "-c", "echo $AWS_SECRET_ACCESS_KEY && echo going to sleep... && sleep 10000"]
+        env:
+        - name: AWS_SECRET_ACCESS_KEY
+          value: vault:secret/data/accounts/aws#AWS_SECRET_ACCESS_KEY
+        resources:
+          limits:
+            memory: "128Mi"
+            cpu: "100m"
+      - name: redis
+        image: redis
+        env:
+        - name: AWS_SECRET_ACCESS_KEY
+          value: vault:secret/data/accounts/aws#AWS_SECRET_ACCESS_KEY
+        resources:
+          limits:
+            memory: "128Mi"
+            cpu: "100m"
+      - name: nginx
+        image: nginx
+        env:
+        - name: AWS_SECRET_ACCESS_KEY
+          value: vault:secret/data/accounts/aws#AWS_SECRET_ACCESS_KEY
+        resources:
+          limits:
+            memory: "128Mi"
+            cpu: "100m"
+

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -29,6 +29,7 @@ const (
 	RegistrySkipVerifyAnnotation          = "vault.security.banzaicloud.io/registry-skip-verify"
 	MutateAnnotation                      = "vault.security.banzaicloud.io/mutate"
 	MutateProbesAnnotation                = "vault.security.banzaicloud.io/mutate-probes"
+	MutateContainersAnnotation            = "vault.security.banzaicloud.io/mutate-containers"
 
 	// Vault-env/Secret-init annotations
 	// NOTE: Change these once vault-env has been replaced with secret-init

--- a/pkg/webhook/config.go
+++ b/pkg/webhook/config.go
@@ -16,6 +16,7 @@ package webhook
 
 import (
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/slok/kubewebhook/v2/pkg/model"
@@ -89,6 +90,7 @@ type VaultConfig struct {
 	ObjectNamespace               string
 	MutateProbes                  bool
 	Token                         string
+	MutateContainers              map[string]bool
 }
 
 func parseVaultConfig(obj metav1.Object, ar *model.AdmissionReview) VaultConfig {
@@ -447,6 +449,18 @@ func parseVaultConfig(obj metav1.Object, ar *model.AdmissionReview) VaultConfig 
 	}
 
 	vaultConfig.Token = viper.GetString("vault_token")
+
+	// Parse mutate-containers annotation
+	vaultConfig.MutateContainers = make(map[string]bool)
+	if val, ok := annotations[common.MutateContainersAnnotation]; ok && val != "" {
+		containerNames := strings.Split(val, ",")
+		for _, name := range containerNames {
+			trimmedName := strings.TrimSpace(name)
+			if trimmedName != "" {
+				vaultConfig.MutateContainers[trimmedName] = true
+			}
+		}
+	}
 
 	return vaultConfig
 }

--- a/pkg/webhook/pod.go
+++ b/pkg/webhook/pod.go
@@ -241,6 +241,13 @@ func (mw *MutatingWebhook) mutateContainers(ctx context.Context, containers []co
 	mutated := false
 
 	for i, container := range containers {
+		// If mutate-containers annotation is set, check if this container should be mutated
+		if len(vaultConfig.MutateContainers) > 0 {
+			if !vaultConfig.MutateContainers[container.Name] {
+				continue
+			}
+		}
+
 		var envVars []corev1.EnvVar
 		if len(container.EnvFrom) > 0 {
 			envFrom, err := mw.lookForEnvFrom(ctx, container.EnvFrom, vaultConfig.ObjectNamespace)


### PR DESCRIPTION
**Changes**

This PR introduces a new annotation:

`vault.security.banzaicloud.io/mutate-containers`

which allows users to explicitly define which containers inside a Pod should be mutated by the vault-secrets-webhook.

Prior to this change, the webhook injected vault-env into all containers and initContainers when vault-env-from-path annotation was present.
This behavior caused issues in workloads where only a subset of containers should receive Vault secrets, while others (e.g., sidecars, system init containers, Argo "wait" containers, etc.) must not be wrapped.

The new annotation accepts a comma-separated list of container names and limits mutation only to containers listed there.
If the annotation is omitted, the webhook continues to mutate all containers, maintaining backward compatibility.



**Motivation**

Many real-world Kubernetes workloads include containers that must not be wrapped with vault-env, such as:

system init containers performing filesystem operations,

logging, metrics, or service mesh sidecars,

Argo Workflows "wait" or "main" containers with strict command/entrypoint assumptions.

Injecting vault-env into these containers may break workloads or cause unexpected failures.

This feature provides fine-grained control by allowing users to specify exactly which containers require Vault secret injection.

Example:
```
annotations:
  vault.security.banzaicloud.io/vault-env-from-path: "secret/data/app"
  vault.security.banzaicloud.io/mutate-containers: "app,worker"
```

Only the app and worker containers will be mutated, while all others remain untouched.

This provides safer, more predictable webhook behavior in complex Pod specifications and avoids relying on excluding mutation via external admission controllers (e.g., Kyverno).