### PR TITLE
fix: missing IPC_LOCK capability in vault-agent initContainer

### DIFF
--- a/e2e/test/deployment-init-useagent-seccontext.yaml
+++ b/e2e/test/deployment-init-useagent-seccontext.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-deployment-init-useagent-seccontext-config
+data:
+  config.hcl: |
+    auto_auth {
+      method "kubernetes" {
+        mount_path = "auth/kubernetes"
+        config = {
+          role = "default"
+        }
+      }
+      sink "file" {
+        config = {
+          path = "/vault/.vault-token"
+        }
+      }
+    }
+    vault {
+        retry {
+            backoff = "1s"
+        }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment-init-useagent-seccontext
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: test-deployment-init-useagent-seccontext
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: test-deployment-init-useagent-seccontext
+      annotations:
+        vault.security.banzaicloud.io/vault-addr: "https://vault.default.svc.cluster.local:8200"
+        vault.security.banzaicloud.io/vault-tls-secret: vault-tls
+        vault.security.banzaicloud.io/vault-agent: "true"
+        vault.security.banzaicloud.io/vault-agent-configmap: test-deployment-init-useagent-seccontext-config
+        vault.security.banzaicloud.io/run-as-non-root: "true"
+        vault.security.banzaicloud.io/run-as-user: "1000"
+        vault.security.banzaicloud.io/run-as-group: "1000"
+    spec:
+      containers:
+        - name: alpine
+          image: alpine
+          command: ["sh", "-c", "echo $AWS_SECRET_ACCESS_KEY && echo going to sleep... && sleep 10000"]
+          env:
+          - name: AWS_SECRET_ACCESS_KEY
+            value: vault:secret/data/accounts/aws#AWS_SECRET_ACCESS_KEY
+          resources:
+            limits:
+              memory: "128Mi"
+              cpu: "100m"

--- a/e2e/webhook_test.go
+++ b/e2e/webhook_test.go
@@ -257,7 +257,50 @@ func TestPodMutation(t *testing.T) {
 		}).
 		Feature()
 
-	testenv.Test(t, deployment, deploymentSeccontext, deploymentTemplating, deploymentInitSeccontext)
+	deploymentInitVaultAgentSeccontext := applyResource(features.New("deployment-init-useagent-seccontext"), "deployment-init-useagent-seccontext.yaml").
+		Assess("available", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			deployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-deployment-init-useagent-seccontext", Namespace: cfg.Namespace()},
+			}
+
+			// wait for the deployment to become available
+			err := wait.For(conditions.New(cfg.Client().Resources()).DeploymentConditionMatch(deployment, appsv1.DeploymentAvailable, v1.ConditionTrue), wait.WithTimeout(2*time.Minute))
+			require.NoError(t, err)
+
+			return ctx
+		}).
+		Assess("security context has correct capabilities and init containers executed successfully", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			r := cfg.Client().Resources()
+
+			pods := &v1.PodList{}
+
+			err := r.List(ctx, pods, resources.WithLabelSelector("app.kubernetes.io/name=test-deployment-init-useagent-seccontext"))
+			require.NoError(t, err)
+
+			if pods == nil || len(pods.Items) == 0 {
+				t.Fatal("no pods found")
+			}
+
+			// wait for the container to become available
+			err = wait.For(conditions.New(r).ContainersReady(&pods.Items[0]), wait.WithTimeout(2*time.Minute))
+			require.NoError(t, err)
+
+			securityContext := pods.Items[0].Spec.InitContainers[0].SecurityContext
+
+			require.NotNil(t, securityContext.RunAsNonRoot)
+			assert.Equal(t, true, *securityContext.RunAsNonRoot)
+			require.NotNil(t, securityContext.RunAsUser)
+			assert.Equal(t, int64(1000), *securityContext.RunAsUser)
+			require.NotNil(t, securityContext.RunAsGroup)
+			assert.Equal(t, int64(1000), *securityContext.RunAsGroup)
+
+			require.NotNil(t, securityContext.Capabilities)
+			assert.Equal(t, []v1.Capability{"CHOWN", "SETFCAP", "SETGID", "SETPCAP", "SETUID", "IPC_LOCK"}, securityContext.Capabilities.Add)
+			return ctx
+		}).
+		Feature()
+
+	testenv.Test(t, deployment, deploymentSeccontext, deploymentTemplating, deploymentInitSeccontext, deploymentInitVaultAgentSeccontext)
 }
 
 func applyResource(builder *features.FeatureBuilder, file string) *features.FeatureBuilder {

--- a/pkg/webhook/pod.go
+++ b/pkg/webhook/pod.go
@@ -707,6 +707,7 @@ func getInitContainers(originalContainers []corev1.Container, podSecurityContext
 			"SETGID",
 			"SETPCAP",
 			"SETUID",
+			"IPC_LOCK",
 		}
 
 		containers = append(containers, corev1.Container{

--- a/pkg/webhook/pod_test.go
+++ b/pkg/webhook/pod_test.go
@@ -762,6 +762,7 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 				"SETGID",
 				"SETPCAP",
 				"SETUID",
+				"IPC_LOCK",
 			},
 			Drop: []corev1.Capability{
 				"ALL",


### PR DESCRIPTION
## Overview

Vault 2.0.1 now requires `IPC_LOCK` capability to work. When running the vault-agent as initContainer that capability was missing.

Added `e2e` tests to confirm that workloads using vault-agent as initContainer can start.

Fixes #952


## Notes for reviewer

Running the new `deployment-init-useagent-seccontext` found in `webhook_test.go` without the added `IPC_LOCK` capability in `pod.go` will show that the deployment never becomes available.
