### PR TITLE
fix(webhook): apply vault-addr allowlist to pod injection

### DIFF
--- a/pkg/webhook/config.go
+++ b/pkg/webhook/config.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"time"
 
+	"emperror.dev/errors"
 	"github.com/slok/kubewebhook/v2/pkg/model"
 	"github.com/spf13/viper"
 	corev1 "k8s.io/api/core/v1"
@@ -92,7 +93,7 @@ type VaultConfig struct {
 	Token                         string
 }
 
-func parseVaultConfig(obj metav1.Object, ar *model.AdmissionReview) VaultConfig {
+func parseVaultConfig(obj metav1.Object, ar *model.AdmissionReview) (VaultConfig, error) {
 	vaultConfig := VaultConfig{
 		ObjectNamespace: ar.Namespace,
 	}
@@ -102,7 +103,7 @@ func parseVaultConfig(obj metav1.Object, ar *model.AdmissionReview) VaultConfig 
 	if val := annotations[common.MutateAnnotation]; val == "skip" {
 		vaultConfig.Skip = true
 
-		return vaultConfig
+		return vaultConfig, nil
 	}
 
 	if val, ok := annotations[common.VaultAddrAnnotation]; ok {
@@ -110,6 +111,12 @@ func parseVaultConfig(obj metav1.Object, ar *model.AdmissionReview) VaultConfig 
 		vaultConfig.AddrFromObject = true
 	} else {
 		vaultConfig.Addr = viper.GetString("vault_addr")
+	}
+
+	if vaultConfig.AddrFromObject {
+		if err := common.ValidateObjectAddr(vaultConfig.Addr, vaultAddrPolicy()); err != nil {
+			return vaultConfig, errors.Wrap(err, "rejected Vault address from object annotation")
+		}
 	}
 
 	if val, ok := annotations[common.VaultRoleAnnotation]; ok {
@@ -450,7 +457,7 @@ func parseVaultConfig(obj metav1.Object, ar *model.AdmissionReview) VaultConfig 
 
 	vaultConfig.Token = viper.GetString("vault_token")
 
-	return vaultConfig
+	return vaultConfig, nil
 }
 
 func getPullPolicy(pullPolicyStr string) corev1.PullPolicy {

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -51,7 +51,10 @@ type MutatingWebhook struct {
 }
 
 func (mw *MutatingWebhook) VaultSecretsMutator(ctx context.Context, ar *model.AdmissionReview, obj metav1.Object) (*mutating.MutatorResult, error) {
-	vaultConfig := parseVaultConfig(obj, ar)
+	vaultConfig, err := parseVaultConfig(obj, ar)
+	if err != nil {
+		return &mutating.MutatorResult{}, err
+	}
 
 	if vaultConfig.Skip {
 		return &mutating.MutatorResult{}, nil
@@ -212,14 +215,6 @@ func (mw *MutatingWebhook) newVaultClient(ctx context.Context, vaultConfig Vault
 	if clientConfig.Error != nil {
 		vaultAuthAttemptsErrorsCount.WithLabelValues("config_error").Inc()
 		return nil, clientConfig.Error
-	}
-
-	// Validate before any connection or ServiceAccount token mint.
-	if vaultConfig.AddrFromObject {
-		if err := common.ValidateObjectAddr(vaultConfig.Addr, vaultAddrPolicy()); err != nil {
-			vaultAuthAttemptsErrorsCount.WithLabelValues("config_error").Inc()
-			return nil, errors.Wrap(err, "rejected Vault address from object annotation")
-		}
 	}
 
 	clientConfig.Address = vaultConfig.Addr

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -23,12 +23,15 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/slok/kubewebhook/v2/pkg/model"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/bank-vaults/vault-secrets-webhook/pkg/common"
 )
 
 func TestNewVaultClientMetrics(t *testing.T) {
@@ -136,10 +139,7 @@ func TestNewVaultClientMetrics(t *testing.T) {
 	}
 }
 
-func TestNewVaultClientRejectsObjectAddr(t *testing.T) {
-	logger := slog.New(slog.DiscardHandler)
-	require.NoError(t, os.Setenv("KUBERNETES_NAMESPACE", "test-namespace"))
-
+func TestParseVaultConfigRejectsObjectAddr(t *testing.T) {
 	tests := []struct {
 		name      string
 		addr      string
@@ -172,39 +172,22 @@ func TestNewVaultClientRejectsObjectAddr(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			vaultAuthAttemptsCount.Reset()
-			vaultAuthAttemptsErrorsCount.Reset()
 			viper.Set("vault_addr_allowlist", tt.allowlist)
 			t.Cleanup(viper.Reset)
 
-			mw, err := NewMutatingWebhook(logger, fake.NewClientset())
-			require.NoError(t, err)
-
-			vaultConfig := VaultConfig{
-				Addr:                tt.addr,
-				AddrFromObject:      true,
-				SkipVerify:          true,
-				Role:                "test-role",
-				Path:                "kubernetes",
-				VaultServiceAccount: "high-priv-sa",
-				ObjectNamespace:     "test-namespace",
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{common.VaultAddrAnnotation: tt.addr},
+				},
 			}
 
-			_, err = mw.newVaultClient(t.Context(), vaultConfig)
+			_, err := parseVaultConfig(pod, &model.AdmissionReview{})
 
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "rejected Vault address from object annotation")
-				assert.Equal(t, float64(1), testutil.ToFloat64(vaultAuthAttemptsErrorsCount.WithLabelValues("config_error")),
-					"address rejection must record a config_error")
-				assert.Equal(t, float64(0), testutil.ToFloat64(vaultAuthAttemptsErrorsCount.WithLabelValues("kubernetes_error")),
-					"rejection must happen before the ServiceAccount token path")
 			} else {
-				if err != nil {
-					assert.NotContains(t, err.Error(), "rejected Vault address from object annotation")
-				}
-				assert.Equal(t, float64(0), testutil.ToFloat64(vaultAuthAttemptsErrorsCount.WithLabelValues("config_error")),
-					"a valid allowlisted address must not record a config_error")
+				require.NoError(t, err)
 			}
 		})
 	}


### PR DESCRIPTION
The `vault-addr` allowlist was only enforced in `newVaultClient` (object/secret/configmap paths), so pod secret injection accepted any object-supplied `vault-addr`. Move validation into `parseVaultConfig` so it covers every mutated object — Pods included — matching the skip-verify gate.

## Test plan
- [x] `TestParseVaultConfigRejectsObjectAddr` covers IMDS, non-allowlisted, and userinfo addresses on the pod path
- [x] `go test ./...` green